### PR TITLE
[codex] Update Apache TsFile wording

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Apache IoTDB TsFile Viewer
+Apache TsFile Viewer
 Copyright 2024-2026 The Apache Software Foundation
 
 This product includes software developed at

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -34,7 +34,7 @@
   <artifactId>tsfile-viewer</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <name>TSFile Viewer</name>
-  <description>Web-based application for viewing and analyzing Apache IoTDB TSFile format data</description>
+  <description>Web-based application for viewing and analyzing Apache TsFile format data</description>
 
   <properties>
     <java.version>17</java.version>

--- a/backend/src/main/java/org/apache/tsfile/viewer/TsFileViewerApplication.java
+++ b/backend/src/main/java/org/apache/tsfile/viewer/TsFileViewerApplication.java
@@ -26,8 +26,8 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 /**
  * Main application class for TSFile Viewer.
  *
- * <p>TSFile Viewer is a web-based application for viewing and analyzing Apache IoTDB TSFile format
- * data through an interactive web interface.
+ * <p>TSFile Viewer is a web-based application for viewing and analyzing Apache TsFile format data
+ * through an interactive web interface.
  */
 @SpringBootApplication
 @ConfigurationPropertiesScan

--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -127,7 +127,7 @@ export default {
    {
      "app": {
        "title": "TSFileビューア",
-       "description": "Apache IoTDB TSFile形式データの表示と分析ツール"
+       "description": "Apache TsFile形式データの表示と分析ツール"
      }
    }
    ```

--- a/docs/I18N.zh-CN.md
+++ b/docs/I18N.zh-CN.md
@@ -127,7 +127,7 @@ export default {
    {
      "app": {
        "title": "TSFileビューア",
-       "description": "Apache IoTDB TSFile形式データの表示と分析ツール"
+       "description": "Apache TsFile形式データの表示と分析ツール"
      }
    }
    ```

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -2,7 +2,7 @@
   "tsfile": {
     "app": {
       "title": "TSFile Viewer",
-      "description": "Apache IoTDB TSFile Format Data Viewing and Analysis Tool"
+      "description": "Apache TsFile Format Data Viewing and Analysis Tool"
     },
     "nav": {
       "home": "Home",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -2,7 +2,7 @@
   "tsfile": {
     "app": {
       "title": "TSFile 查看器",
-      "description": "Apache IoTDB TSFile 格式数据查看和分析工具"
+      "description": "Apache TsFile 格式数据查看和分析工具"
     },
     "nav": {
       "home": "首页",


### PR DESCRIPTION
## Summary

- Replace direct product wording from "Apache IoTDB TSFile/TsFile" to "Apache TsFile" in NOTICE, backend metadata, app comments, frontend locale descriptions, and i18n docs.
- Leave IoTDB-specific implementation references intact where they describe validation behavior borrowed from IoTDB internals.

## Validation

- `rg -n "Apache IoTDB TSFile|Apache IoTDB TsFile|IoTDB TSFile|IoTDB TsFile" .` returns no matches.
- `mvn test` from `backend/` passes: 285 tests run, 0 failures, 0 errors, 17 skipped.