### PR TITLE
fix: upgrade tsfile library from 2.2.0 to 2.3.0

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -38,7 +38,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <tsfile.version>2.2.0</tsfile.version>
+    <tsfile.version>2.3.0</tsfile.version>
     <caffeine.version>3.2.0</caffeine.version>
     <springdoc.version>2.8.0</springdoc.version>
     <google-java-format.version>1.22.0</google-java-format.version>


### PR DESCRIPTION
Fixes ArrayIndexOutOfBoundsException in TableSchema.deserialize when reading TsFile files created by newer SDK versions.